### PR TITLE
#1: More effective data types

### DIFF
--- a/clickhouse/geoip_city_blocks_ipv4_dictionary.xml
+++ b/clickhouse/geoip_city_blocks_ipv4_dictionary.xml
@@ -31,17 +31,17 @@
             </attribute>
             <attribute>
                 <name>represented_country_geoname_id</name>
-                <type>String</type>
-                <null_value>?</null_value>
-            </attribute>
-            <attribute>
-                <name>is_anonymous_proxy</name>
                 <type>UInt32</type>
                 <null_value>0</null_value>
             </attribute>
             <attribute>
+                <name>is_anonymous_proxy</name>
+                <type>UInt8</type>
+                <null_value>0</null_value>
+            </attribute>
+            <attribute>
                 <name>is_satellite_provider</name>
-                <type>UInt32</type>
+                <type>UInt8</type>
                 <null_value>0</null_value>
             </attribute>
             <attribute>

--- a/clickhouse/geoip_city_blocks_ipv6_dictionary.xml
+++ b/clickhouse/geoip_city_blocks_ipv6_dictionary.xml
@@ -31,17 +31,17 @@
             </attribute>
             <attribute>
                 <name>represented_country_geoname_id</name>
-                <type>String</type>
-                <null_value>?</null_value>
-            </attribute>
-            <attribute>
-                <name>is_anonymous_proxy</name>
                 <type>UInt32</type>
                 <null_value>0</null_value>
             </attribute>
             <attribute>
+                <name>is_anonymous_proxy</name>
+                <type>UInt8</type>
+                <null_value>0</null_value>
+            </attribute>
+            <attribute>
                 <name>is_satellite_provider</name>
-                <type>UInt32</type>
+                <type>UInt8</type>
                 <null_value>0</null_value>
             </attribute>
             <attribute>

--- a/clickhouse/geoip_city_locations_en_dictionary.xml
+++ b/clickhouse/geoip_city_locations_en_dictionary.xml
@@ -68,8 +68,8 @@
             </attribute>
             <attribute>
                 <name>metro_code</name>
-                <type>String</type>
-                <null_value></null_value>
+                <type>UInt32</type>
+                <null_value>0</null_value>
             </attribute>
             <attribute>
                 <name>time_zone</name>
@@ -78,8 +78,8 @@
             </attribute>
             <attribute>
                 <name>is_in_european_union</name>
-                <type>String</type>
-                <null_value></null_value>
+                <type>UInt8</type>
+                <null_value>0</null_value>
             </attribute>
         </structure>
     </dictionary>

--- a/clickhouse/geoip_country_blocks_ipv4_dictionary.xml
+++ b/clickhouse/geoip_country_blocks_ipv4_dictionary.xml
@@ -31,17 +31,17 @@
             </attribute>
             <attribute>
                 <name>represented_country_geoname_id</name>
-                <type>String</type>
-                <null_value>?</null_value>
-            </attribute>
-            <attribute>
-                <name>is_anonymous_proxy</name>
                 <type>UInt32</type>
                 <null_value>0</null_value>
             </attribute>
             <attribute>
+                <name>is_anonymous_proxy</name>
+                <type>UInt8</type>
+                <null_value>0</null_value>
+            </attribute>
+            <attribute>
                 <name>is_satellite_provider</name>
-                <type>UInt32</type>
+                <type>UInt8</type>
                 <null_value>0</null_value>
             </attribute>
         </structure>

--- a/clickhouse/geoip_country_blocks_ipv6_dictionary.xml
+++ b/clickhouse/geoip_country_blocks_ipv6_dictionary.xml
@@ -31,17 +31,17 @@
             </attribute>
             <attribute>
                 <name>represented_country_geoname_id</name>
-                <type>String</type>
-                <null_value>?</null_value>
-            </attribute>
-            <attribute>
-                <name>is_anonymous_proxy</name>
                 <type>UInt32</type>
                 <null_value>0</null_value>
             </attribute>
             <attribute>
+                <name>is_anonymous_proxy</name>
+                <type>UInt8</type>
+                <null_value>0</null_value>
+            </attribute>
+            <attribute>
                 <name>is_satellite_provider</name>
-                <type>UInt32</type>
+                <type>UInt8</type>
                 <null_value>0</null_value>
             </attribute>
         </structure>

--- a/clickhouse/geoip_country_locations_en_dictionary.xml
+++ b/clickhouse/geoip_country_locations_en_dictionary.xml
@@ -43,8 +43,8 @@
             </attribute>
             <attribute>
                 <name>is_in_european_union</name>
-                <type>String</type>
-                <null_value></null_value>
+                <type>UInt8</type>
+                <null_value>0</null_value>
             </attribute>
         </structure>
     </dictionary>


### PR DESCRIPTION
There's a possibility to use some more efficient data types for dictionaries' fields like is_anonymous_proxy or represented_country_geoname_id