### PR TITLE
Use CH option rather than sed to handle apostrophes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,3 @@ RUN pwd
 RUN ls -la
 RUN ls -la /etc/clickhouse-server
 RUN ls -la /tmp
-
-RUN cat /etc/clickhouse-server/GeoLite2-City-Locations-en.csv | sed 's/'"'"'/\\'"'"'/g' > /etc/clickhouse-server/GeoLite2-City-Locations-en-fixed.csv

--- a/clickhouse/geoip_city_locations_en_dictionary.xml
+++ b/clickhouse/geoip_city_locations_en_dictionary.xml
@@ -4,9 +4,12 @@
         <name>geoip_city_locations_en</name>
         <source>
             <file>
-                <path>/etc/clickhouse-server/GeoLite2-City-Locations-en-fixed.csv</path>
+                <path>/etc/clickhouse-server/GeoLite2-City-Locations-en.csv</path>
                 <format>CSVWithNames</format>
             </file>
+            <settings>
+                <format_csv_allow_single_quotes>0</format_csv_allow_single_quotes>
+            </settings>
         </source>
         <lifetime>300</lifetime>
         <layout>


### PR DESCRIPTION
Version 21 of Clickhouse no longer supports escaping a single quote in a value like `\'`. However, there is an option that disables the use of single quotes (which brings Clickhouse more in line with the CSV standard).

This PR removes the escaping (via sed) and instead uses a format option on the Clickhouse dictionary definition.