### PR TITLE
Add config to support dictGetString('xx', 'network')

### DIFF
--- a/clickhouse/dictionaries/geoip_asn_blocks_ipv4_dictionary.xml
+++ b/clickhouse/dictionaries/geoip_asn_blocks_ipv4_dictionary.xml
@@ -10,7 +10,11 @@
         </source>
         <lifetime>300</lifetime>
         <layout>
-            <ip_trie/>
+            <ip_trie>
+                <!-- Key attribute `prefix` can be retrieved via dictGetString. -->
+                <!-- This option increases memory usage. -->
+                <access_to_key_from_attributes>true</access_to_key_from_attributes>
+            </ip_trie>
         </layout>
         <structure>
             <key>

--- a/clickhouse/dictionaries/geoip_asn_blocks_ipv6_dictionary.xml
+++ b/clickhouse/dictionaries/geoip_asn_blocks_ipv6_dictionary.xml
@@ -10,7 +10,11 @@
         </source>
         <lifetime>300</lifetime>
         <layout>
-            <ip_trie/>
+            <ip_trie>
+                 <!-- Key attribute `prefix` can be retrieved via dictGetString. -->
+                <!-- This option increases memory usage. -->
+                <access_to_key_from_attributes>true</access_to_key_from_attributes>
+            </ip_trie>
         </layout>
         <structure>
             <key>

--- a/clickhouse/dictionaries/geoip_city_blocks_ipv4_dictionary.xml
+++ b/clickhouse/dictionaries/geoip_city_blocks_ipv4_dictionary.xml
@@ -10,7 +10,11 @@
         </source>
         <lifetime>300</lifetime>
         <layout>
-            <ip_trie/>
+            <ip_trie>
+                 <!-- Key attribute `prefix` can be retrieved via dictGetString. -->
+                <!-- This option increases memory usage. -->
+                <access_to_key_from_attributes>true</access_to_key_from_attributes>
+            </ip_trie>
         </layout>
         <structure>
             <key>

--- a/clickhouse/dictionaries/geoip_city_blocks_ipv6_dictionary.xml
+++ b/clickhouse/dictionaries/geoip_city_blocks_ipv6_dictionary.xml
@@ -10,7 +10,11 @@
         </source>
         <lifetime>300</lifetime>
         <layout>
-            <ip_trie/>
+            <ip_trie>
+                 <!-- Key attribute `prefix` can be retrieved via dictGetString. -->
+                <!-- This option increases memory usage. -->
+                <access_to_key_from_attributes>true</access_to_key_from_attributes>
+            </ip_trie>
         </layout>
         <structure>
             <key>

--- a/clickhouse/dictionaries/geoip_country_blocks_ipv4_dictionary.xml
+++ b/clickhouse/dictionaries/geoip_country_blocks_ipv4_dictionary.xml
@@ -10,7 +10,11 @@
         </source>
         <lifetime>300</lifetime>
         <layout>
-            <ip_trie/>
+            <ip_trie>
+                 <!-- Key attribute `prefix` can be retrieved via dictGetString. -->
+                <!-- This option increases memory usage. -->
+                <access_to_key_from_attributes>true</access_to_key_from_attributes>
+            </ip_trie>
         </layout>
         <structure>
             <key>

--- a/clickhouse/dictionaries/geoip_country_blocks_ipv6_dictionary.xml
+++ b/clickhouse/dictionaries/geoip_country_blocks_ipv6_dictionary.xml
@@ -10,7 +10,11 @@
         </source>
         <lifetime>300</lifetime>
         <layout>
-            <ip_trie/>
+            <ip_trie>
+                 <!-- Key attribute `prefix` can be retrieved via dictGetString. -->
+                <!-- This option increases memory usage. -->
+                <access_to_key_from_attributes>true</access_to_key_from_attributes>
+            </ip_trie>
         </layout>
         <structure>
             <key>


### PR DESCRIPTION
support
```sql
select dictGetString('geoip_city_blocks_ipv4', 'network', tuple(IPv4StringToNum('1.2.3.4')));
```

to get network cidr.
easy to join dict_table or filtered to same network addr

Need version >= v21.1

first include in v20.13.1.5579-testing (https://github.com/ClickHouse/ClickHouse/commit/1e3bd37380a1331727fa93443d20835c5cbc2a6f)

document:
https://clickhouse.com/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-layout#ip_trie